### PR TITLE
Rename HideHeaders to ShowHeaders and simplify logic

### DIFF
--- a/Terminal.Gui/Views/TableView/TableView.cs
+++ b/Terminal.Gui/Views/TableView/TableView.cs
@@ -262,14 +262,14 @@ namespace Terminal.Gui {
 					line++;
 				}
 
-				if (!Style.HideHeaders) {
+				if (Style.ShowHeaders) {
 					RenderHeaderMidline (line, columnsToRender);
 					line++;
+				}
 
-					if (Style.ShowHorizontalHeaderUnderline) {
-						RenderHeaderUnderline (line, bounds.Width, columnsToRender);
-						line++;
-					}
+				if (Style.ShowHorizontalHeaderUnderline) {
+					RenderHeaderUnderline (line, bounds.Width, columnsToRender);
+					line++;
 				}
 			}
 
@@ -318,13 +318,7 @@ namespace Terminal.Gui {
 		/// <returns></returns>
 		private int GetHeaderHeight ()
 		{
-			if (Style.HideHeaders) {
-				if (Style.ShowHorizontalHeaderOverline)
-					return 1;
-				return 0;
-			}
-
-			int heightRequired = 1;
+			int heightRequired = Style.ShowHeaders ? 1 : 0;
 
 			if (Style.ShowHorizontalHeaderOverline)
 				heightRequired++;
@@ -1777,11 +1771,12 @@ namespace Terminal.Gui {
 		public class TableStyle {
 
 			/// <summary>
-			/// Gets or sets a flag indicating whether to suppress rendering headers of a <see cref="TableView"/>.
-			/// Defaults to false.  ShowHorizontalHeaderOverline may still be used, and AlwaysShowHeaders will
-			/// always show it.
+			/// Gets or sets a flag indicating whether to render headers of a <see cref="TableView"/>.
+			/// Defaults to <see langword="true"/>.
 			/// </summary>
-			public bool HideHeaders { get; set; } = false;
+			/// <remarks><see cref="ShowHorizontalHeaderOverline"/>, <see cref="ShowHorizontalHeaderUnderline"/> etc
+			/// may still be used even if <see cref="ShowHeaders"/> is <see langword="false"/>.</remarks>
+			public bool ShowHeaders { get; set; } = true;
 
 			/// <summary>
 			/// When scrolling down always lock the column headers in place as the first row of the table

--- a/UICatalog/Scenarios/TableEditor.cs
+++ b/UICatalog/Scenarios/TableEditor.cs
@@ -16,7 +16,7 @@ namespace UICatalog.Scenarios {
 	[ScenarioCategory ("Top Level Windows")]
 	public class TableEditor : Scenario {
 		TableView tableView;
-		private MenuItem miHideHeaders;
+		private MenuItem miShowHeaders;
 		private MenuItem miAlwaysShowHeaders;
 		private MenuItem miHeaderOverline;
 		private MenuItem miHeaderMidline;
@@ -56,7 +56,7 @@ namespace UICatalog.Scenarios {
 					new MenuItem ("_Quit", "", () => Quit()),
 				}),
 				new MenuBarItem ("_View", new MenuItem [] {
-					miHideHeaders = new MenuItem ("_HideHeaders", "", () => ToggleHideHeaders()){Checked = tableView.Style.HideHeaders, CheckType = MenuItemCheckStyle.Checked },
+					miShowHeaders = new MenuItem ("_ShowHeaders", "", () => ToggleShowHeaders()){Checked = tableView.Style.ShowHeaders, CheckType = MenuItemCheckStyle.Checked },
 					miAlwaysShowHeaders = new MenuItem ("_AlwaysShowHeaders", "", () => ToggleAlwaysShowHeaders()){Checked = tableView.Style.AlwaysShowHeaders, CheckType = MenuItemCheckStyle.Checked },
 					miHeaderOverline = new MenuItem ("_HeaderOverLine", "", () => ToggleOverline()){Checked = tableView.Style.ShowHorizontalHeaderOverline, CheckType = MenuItemCheckStyle.Checked },
 					miHeaderMidline = new MenuItem ("_HeaderMidLine", "", () => ToggleHeaderMidline()){Checked = tableView.Style.ShowVerticalHeaderLines, CheckType = MenuItemCheckStyle.Checked },
@@ -376,10 +376,10 @@ namespace UICatalog.Scenarios {
 			tableView.Update ();
 		}
 
-		private void ToggleHideHeaders ()
+		private void ToggleShowHeaders ()
 		{
-			miHideHeaders.Checked = !miHideHeaders.Checked;
-			tableView.Style.HideHeaders = (bool)miHideHeaders.Checked;
+			miShowHeaders.Checked = !miShowHeaders.Checked;
+			tableView.Style.ShowHeaders = (bool)miShowHeaders.Checked;
 			tableView.Update ();
 		}
 

--- a/UnitTests/Views/TableViewTests.cs
+++ b/UnitTests/Views/TableViewTests.cs
@@ -456,15 +456,14 @@ namespace Terminal.Gui.ViewsTests {
 		}
 
 		[Fact, AutoInitShutdown]
-		public void TableView_HideHeaders_True_ExactBounds ()
+		public void TableView_ShowHeadersFalse_AndNoHeaderLines ()
 		{
-			var tv = SetUpMiniTable ();
+			var tv = GetABCDEFTableView (out _);
+			tv.Bounds = new Rect (0, 0, 5, 5);
 
-			// the thing we are testing
-			tv.Style.HideHeaders = true;
+			tv.Style.ShowHeaders = false;
 			tv.Style.ShowHorizontalHeaderOverline = false;
-			// width exactly matches the max col widths
-			tv.Bounds = new Rect (0, 0, 5, 1);
+			tv.Style.ShowHorizontalHeaderUnderline = false;
 
 			tv.Redraw (tv.Bounds);
 
@@ -472,53 +471,69 @@ namespace Terminal.Gui.ViewsTests {
 │1│2│
 ";
 			TestHelpers.AssertDriverContentsAre (expected, output);
+		}
+		[Fact, AutoInitShutdown]
+		public void TableView_ShowHeadersFalse_OverlineTrue ()
+		{
+			var tv = GetABCDEFTableView (out _);
+			tv.Bounds = new Rect (0, 0, 5, 5);
 
-			// test borders without headers
-			tv.Style.ShowHorizontalHeaderUnderline = false;
+			tv.Style.ShowHeaders = false;
 			tv.Style.ShowHorizontalHeaderOverline = true;
-			// width exactly matches the max col widths
-			tv.Bounds = new Rect (0, 0, 5, 2);
-
-			tv.Redraw (tv.Bounds);
-
-			expected = @"
-┌─┬─┐
-│1│2│
-";
-			TestHelpers.AssertDriverContentsAre (expected, output);
-
-			// test underline is ignored when set to true
-			tv.Style.ShowHorizontalHeaderUnderline = true;
-			// width exactly matches the max col widths
-			tv.Bounds = new Rect (0, 0, 5, 2);
-
-			tv.Redraw (tv.Bounds);
-
-			expected = @"
-┌─┬─┐
-│1│2│
-";
-			TestHelpers.AssertDriverContentsAre (expected, output);
-
-			// test HideHeaders disabling brings back header row
-			tv.Style.HideHeaders = false;
 			tv.Style.ShowHorizontalHeaderUnderline = false;
-			// width exactly matches the max col widths
-			tv.Bounds = new Rect (0, 0, 5, 3);
 
 			tv.Redraw (tv.Bounds);
 
-			expected = @"
+			string expected = @"
 ┌─┬─┐
-│A│B│
 │1│2│
 ";
 			TestHelpers.AssertDriverContentsAre (expected, output);
+		}
+		[Fact, AutoInitShutdown]
+		public void TableView_ShowHeadersFalse_UnderlineTrue ()
+		{
+			var tv = GetABCDEFTableView (out _);
+			tv.Bounds = new Rect (0, 0, 5, 5);
 
-			// Shutdown must be called to safely clean up Application if Init has been called
-			Application.Shutdown ();
+			tv.Style.ShowHeaders = false;
+			tv.Style.ShowHorizontalHeaderOverline = false;
+			tv.Style.ShowHorizontalHeaderUnderline = true;
+			// Horizontal scrolling option is part of the underline
+			tv.Style.ShowHorizontalScrollIndicators = true;
+
+
+			tv.Redraw (tv.Bounds);
+
+			string expected = @"
+├─┼─►
+│1│2│
+";
+			TestHelpers.AssertDriverContentsAre (expected, output);
 		}
 
+		[Fact, AutoInitShutdown]
+		public void TableView_ShowHeadersFalse_AllLines ()
+		{
+			var tv = GetABCDEFTableView (out _);
+			tv.Bounds = new Rect (0, 0, 5, 5);
+
+			tv.Style.ShowHeaders = false;
+			tv.Style.ShowHorizontalHeaderOverline = true;
+			tv.Style.ShowHorizontalHeaderUnderline = true;
+			// Horizontal scrolling option is part of the underline
+			tv.Style.ShowHorizontalScrollIndicators = true;
+
+
+			tv.Redraw (tv.Bounds);
+
+			string expected = @"
+┌─┬─┐
+├─┼─►
+│1│2│
+";
+			TestHelpers.AssertDriverContentsAre (expected, output);
+		}
 
 		[Fact, AutoInitShutdown]
 		public void TableView_ExpandLastColumn_True ()


### PR DESCRIPTION
Hey @Nutzzz I have renamed HideHeaders as ShowHeaders and removed the logic that `HideHeaders` implicitly forces changes to how Show Overline/Underline are handled.